### PR TITLE
Removed Self Destruction from holograms

### DIFF
--- a/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramCandy.prefab
+++ b/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramCandy.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1453633179828689359}
   - component: {fileID: 3779313477978754398}
-  - component: {fileID: -1918328924169863300}
   m_Layer: 0
   m_Name: HologramCandy
   m_TagString: Untagged
@@ -47,19 +46,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationSpeed: 1
---- !u!114 &-1918328924169863300
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4286677981344249017}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ca73d5e0e670b84fb75969e7a82ab44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  countDown: 30
 --- !u!1 &6026589799239414695
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramMoney.prefab
+++ b/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramMoney.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2472793860226958421}
   - component: {fileID: 6467414320412656666}
-  - component: {fileID: 6264765280495329113}
   m_Layer: 0
   m_Name: HologramMoney
   m_TagString: Untagged
@@ -47,19 +46,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationSpeed: 1
---- !u!114 &6264765280495329113
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4476508660732616290}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ca73d5e0e670b84fb75969e7a82ab44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  countDown: 30
 --- !u!1 &6054453558766793046
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramPlush.prefab
+++ b/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramPlush.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 4931026773267832320}
   - component: {fileID: 3935920501655737780}
-  - component: {fileID: -6476398133523969141}
   m_Layer: 0
   m_Name: HologramPlush
   m_TagString: Untagged
@@ -47,19 +46,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationSpeed: 1
---- !u!114 &-6476398133523969141
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3598135447389936435}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ca73d5e0e670b84fb75969e7a82ab44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  countDown: 30
 --- !u!1 &8481712860167448960
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramTech.prefab
+++ b/Assets/Visuals & UI/Shaders/ItemHologram/Holograms/HologramTech.prefab
@@ -10,7 +10,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2456867025135280653}
   - component: {fileID: 4750784507175472069}
-  - component: {fileID: -3314494916842112335}
   m_Layer: 0
   m_Name: HologramTech
   m_TagString: Untagged
@@ -47,19 +46,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rotationSpeed: 1
---- !u!114 &-3314494916842112335
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4140408989915473050}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 2ca73d5e0e670b84fb75969e7a82ab44, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  countDown: 30
 --- !u!1 &5493549078431063303
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
The functionality to destroy holograms on zone shuffle / zone initialization has already been implemented before so to implement this fix simply removing the self destruction component should suffice.

Currently the holograms will stay on scene over their given drop zone untill a new zone state gets iniciated. 

If we want to go back to adding a destruction of the holograms simply add the SelfDestruct script with a defined time.