### PR TITLE
Btl 26 UI Clipping Issue

### DIFF
--- a/Assets/Visuals & UI/UI/CornerUI.prefab
+++ b/Assets/Visuals & UI/UI/CornerUI.prefab
@@ -973,11 +973,11 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 8643059054931807323}
   - {fileID: 1108100208067146681}
   - {fileID: 1595057550421088779}
   - {fileID: 4355761624443689222}
   - {fileID: 1621239576541437599}
+  - {fileID: 8643059054931807323}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}

--- a/Assets/Visuals & UI/UI/UIGenericBanner/GenericAnnoucementGameObject.prefab
+++ b/Assets/Visuals & UI/UI/UIGenericBanner/GenericAnnoucementGameObject.prefab
@@ -662,8 +662,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 190.3
-  m_fontSizeBase: 190.3
+  m_fontSize: 116.6
+  m_fontSizeBase: 116.6
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -698,7 +698,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: -1294.6857, y: 0, z: -1305.4498, w: -96.74932}
+  m_margin: {x: -535.4368, y: 0, z: -443.18066, w: -96.74932}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0


### PR DESCRIPTION
Fixed UI clipping issues with simple changes. 

Player Draw text being offscreen was fixed by making the text area of the GenericAnnocementBanner Line1 TMPro shorter to make the text always fit. There is a possible issue that the Player line may overlap the Draw text, however I cannot test this as I don't have controllers at hand. 

The Powerup effect clipping was fixed by changing the position of the PlayerAnnocement in the canvas hierarchy, causing the powerup banner to cover the player corner for a bit however this avoids ugly clipping 