### PR TITLE
Btl 46 camera clipping

### DIFF
--- a/Assets/Game Function/Scripts/GameUtilities/RoundManager.cs
+++ b/Assets/Game Function/Scripts/GameUtilities/RoundManager.cs
@@ -36,6 +36,8 @@ public class RoundManager : MonoBehaviour
     public GameObject Timer { get; private set; }
     private float secondsRemaining = 0;
 
+    private float endCameraDistance = 4f;
+
     private void Start()
     {
         if (SceneManager.GetActiveScene().name == "Round" || SceneManager.GetActiveScene().name == "Draw")
@@ -300,13 +302,17 @@ public class RoundManager : MonoBehaviour
     private IEnumerator ZoomToPlayer(PlayerController player)
     {
         var baseLoc = Camera.main.transform;
-        var goalLoc = player.Properties.CamAnchor.transform;
+        var goalLoc = player.Position;
+
+        var goalLocPositionPoint = goalLoc + (baseLoc.position - goalLoc).normalized * endCameraDistance;
+
+        var goalLocRotationTowards = Quaternion.LookRotation(goalLoc - baseLoc.position);
         
         for(float i = 0; i < 1.1f; i += 0.17f)
         {
-            var newPosition = Vector3.Lerp(baseLoc.position, goalLoc.position, i);
+            var newPosition = Vector3.Lerp(baseLoc.position, goalLocPositionPoint, i);
             Camera.main.transform.position = newPosition;
-            var newRotation = Quaternion.Lerp(baseLoc.rotation, goalLoc.rotation, i);
+            var newRotation = Quaternion.Lerp(baseLoc.rotation, goalLocRotationTowards, i);
             Camera.main.transform.rotation = newRotation;
             
             yield return new WaitForSeconds(0.02f);

--- a/Assets/Game Function/Scripts/GameUtilities/RoundManager.cs
+++ b/Assets/Game Function/Scripts/GameUtilities/RoundManager.cs
@@ -36,7 +36,7 @@ public class RoundManager : MonoBehaviour
     public GameObject Timer { get; private set; }
     private float secondsRemaining = 0;
 
-    private float endCameraDistance = 4f;
+    public float endCameraDistance = 4f;
 
     private void Start()
     {


### PR DESCRIPTION
Previously the camera simply linearly interpolated to a predetermined camera anchor position on a player prefab, but with these changes the camera will dynamically find the angle and position which to the player should look towards. This added a new parameter to the `RoundManager.cs` called `endCameraDistance` which will determine how far the camera will go towards the player at the end of the round (distance is in units from the player)